### PR TITLE
Try adding github checking out to tag release job

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -42,6 +42,7 @@ jobs:
     needs: [simple_deployment_pipeline]
     runs-on: ubuntu-20.04
     steps:
+      - uses: actions/checkout@v3
       - name: Bump version and push tag
         uses: anothrNick/github-tag-action@1.64.0
         env:


### PR DESCRIPTION
The tag-action -library gives an error for not being a git repository. I try to fix the error this way though needing the first pipeline to end before starting the new one should take care of this.